### PR TITLE
fix(url): fix clickable repo name in grid/table layout

### DIFF
--- a/starcli/layouts.py
+++ b/starcli/layouts.py
@@ -122,9 +122,11 @@ def table_layout(repos):
             repo["language"] = "None"  # make it a string
         if not repo["description"]:  # same here
             repo["description"] = "None"
+        name = Text(repo["name"], overflow="fold")
+        name.stylize(f"yellow link {repo['html_url']}")
 
         table.add_row(
-            repo["name"],
+            name,
             repo["language"],  # so that it can work here
             repo["description"],
             stats,
@@ -156,6 +158,7 @@ def grid_layout(repos):
             repo["description"] = "None"
 
         name = Text(repo["name"], style="bold yellow")
+        name.stylize(f"link {repo['html_url']}")
         language = Text(repo["language"], style="magenta")
         description = Text(repo["description"], style="green")
         stats = Text(stats, style="blue")


### PR DESCRIPTION
<!--If it's just a typo fix or a very small change, you can put your description
here and ignore everything below-->

**Checklist**

- [x] My code is properly formatted using the latest [black](https://github.com/psf/black) <!--Don't worry if you don't know what this is, the formatting checks will still pass-->
- [x] I have added/updated [tests](https://github.com/hedythedev/starcli/tree/main/tests) if needed <!--pytest-->
- [x] I have tried running my code manually <!-- run using `python3 -m starcli` -->
- [x] I have checked for spelling errors <!--The code will be run through codespell-->
<!--
  Please mark this PR as draft if it is still work in progress
  and feel free to add to this checklist if you like
-->


**Description**
 
Right now it only support clickable repo names in list layout by default.
```python
        title = Text(repo["full_name"], overflow="fold")
        title.stylize(f"yellow link {repo['html_url']}")
```

Clickable links to repos are missing in both grid layout and table layout.

My PR added these missing links to get a coherent behavior of repo names across all layouts.

This PR also fixes #112

<!--
- Clearly describe the changes you made
- include before/after screenshots IF NEEDED
- if this pull request can close an issue when merged, link to it here uisng 'resolves #0' or 'closes #0'
More info: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

