### PR TITLE
Fixed Bug #111 + Enhancements

### DIFF
--- a/starcli/layouts.py
+++ b/starcli/layouts.py
@@ -147,7 +147,6 @@ def grid_layout(repos):
 
     panels = []
     for repo in repos:
-
         stats = format_stats(repo["stargazers_count"], repo["forks"])
         # '\n' added here as it would group both text and new line together
         # hence if date_range isn't present the new line will also not be displayed

--- a/starcli/search.py
+++ b/starcli/search.py
@@ -31,16 +31,16 @@ DATE_RANGE_MAP = {
 # Key: Most accepted language symbol identifier
 # Value: list of language title which are correct but throws error with gtrending.fetch_repos method
 LANGUAGE_MAPPING = {
-    'c#': ['csharp'],
-    'c++': ['cpp'],
+    "c#": ["csharp"],
+    "c++": ["cpp"],
 }
 
 STATUS_ACTIONS = {
     "retry": "Failed to retrieve data. Retrying in ",
     "invalid": "The server was unable to process the request.",
-    "unauthorized": "The server did not accept the credentials.\n" \
-        "See: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token\n" #
-        "Maybe you did not give enough scopes?",
+    "unauthorized": "The server did not accept the credentials.\n"
+    "See: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token\n"  #
+    "Maybe you did not give enough scopes?",
     "not_found": "The server indicated no data was found.",
     "unsupported": "The request is not supported.",
     "unknown": "An unknown error occurred.",
@@ -291,14 +291,14 @@ def search_github_trending(
                 if language.lower() in invalid_lang_name:
                     language = alternate_lang_name
                     break
-            
+
             try:
                 gtrending_repo_list += gtrending.fetch_repos(
                     language, spoken_language, since
                 )
             except:
                 secho(
-                    f"Invalid language \"{language}\" passed...",
+                    f'Invalid language "{language}" passed...',
                     fg="bright_red",
                 )
                 return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from random import randint
 from sys import maxsize
 from time import time
+
 # import re
 import os
 import shutil
@@ -40,8 +41,8 @@ class TestCli:
     # def test_no_auth(self):
     #     """Test without --auth"""
     #     result = self.cli_result(auth="")
-        # Testing rich logger output doesn't work
-        # self.assertions(result, in_stderr=("DEBUG: auth: off",))
+    # Testing rich logger output doesn't work
+    # self.assertions(result, in_stderr=("DEBUG: auth: off",))
 
     # def test_incorrect_auth(self):
     #     """Test incorrect credentials provided to --auth"""
@@ -291,7 +292,6 @@ class TestCli:
 
         if nop:
             cli_params.append("--nop")
-
 
         return runner.invoke(cli, cli_params) if cli_params else runner.invoke(cli)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -145,6 +145,7 @@ def test_spoken_language():
         assert repo["full_name"].count("/") >= 1
         assert repo["html_url"] == "https://github.com/" + repo["full_name"]
 
+
 @pytest.mark.xfail()
 def test_date_range():
     """Test search by date range"""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,7 +10,7 @@ from starcli.search import search, search_github_trending
 
 def test_search_language():
     """Test searching by language"""
-    for language in ["python", "Python", "JavaScript", "c"]:
+    for language in ["python", "Python", "JavaScript", "c", "cpp", "csharp"]:
         repos = search([language])
         for repo in repos:
             assert repo["stargazers_count"] >= 0


### PR DESCRIPTION
I have tried to fix the bug mentioned in Issue 111
I have also added an fixes to pass special characters (i.e. "#" in "C#") to the github api endpoint in a query parameter.

**Checklist**

- [x] My code is properly formatted using the latest [black](https://github.com/psf/black)
- [x] I have added/updated [tests](https://github.com/hedythedev/starcli/tree/main/tests)
- [x] I have tried running my code manually
- [x] I have checked for spelling errors



**Description**
- Bug Fix ([resolves #111](https://github.com/hedyhli/starcli/issues/111))
    - I have tackled the error caused by gtrending requests by creating a mapping variable which checks the language passed in by the user. 
    - For example, in,
`-l csharp -d day`
The language "csharp" will be checked in the mapping values. It it is present in any list we replace the language by its key (i.e. c#).
    - PROBLEM: (Test case failure)
       `assert repo["language"].lower() == language.lower()`
       This assertion is in method "test_search_language" in "tests/test_search.py".
       This is because the response contains "c++" as language and the request of user comes with "cpp" as input,
- Enhancements
    - I have also added a changes language query parameter which is passed to github api endpoint so it accepts special characters like "#" (Since special characters need to be encoded before it is passed in as query parameter)
  ```diff
  -   [f"+language:{language}" for language in languages]
  +  [f"+language:{requests.utils.quote(language)}" for language in languages]
  ```

Do let me know your thoughts on these changes.