### PR TITLE
Integrate GitGuard for Enforced Conventional Commit Standards

### DIFF
--- a/.gitguard/commit-msg
+++ b/.gitguard/commit-msg
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+import sys
+import re
+
+
+# Color codes
+RED = "\033[91m"
+GREEN = "\033[92m"
+BOLD = "\033[1m"
+END = "\033[0m"
+
+
+def print_error(commit_msg, error_pos, error_msg, style):
+    TAB = "\t"
+    print("\n" + TAB + commit_msg)
+    print(TAB + " " * error_pos + style + "^-- " + error_msg + END + "\n")
+    print(GREEN +"Convention: <type>(optional scope): <description>\n" + END)
+
+
+def validate_commit_message(commit_msg):
+    prefix_pattern = r"^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|broken)"
+    scope_pattern = r"\([a-z0-9_\-]+\)"
+    message_pattern = r":\s.+$"
+
+    prefix_match = re.match(prefix_pattern, commit_msg)
+    if not prefix_match:
+        print_error(
+            commit_msg, 0, "oops! Invalid prefix. Should be feat, fix, docs, style, refactor, pref, test, chore, ci, build.", RED + BOLD)
+        return False
+
+    rest_msg = commit_msg[len(prefix_match.group()):]
+
+    if rest_msg.startswith('('):
+        scope_match = re.match(scope_pattern, rest_msg)
+        if not scope_match:
+            print_error(commit_msg, len(prefix_match.group()),
+                        "This scope thingy is messed up. It should be like (scope):.", RED + BOLD)
+            return False
+        rest_msg = rest_msg[len(scope_match.group()):]
+
+    if not re.match(message_pattern, rest_msg):
+        error_pos = len(commit_msg) - len(rest_msg)
+        print_error(commit_msg, error_pos,
+                    "Hey genius, message should start with a colon and space.", RED + BOLD)
+        return False
+
+    return True
+
+
+def read_file(file_path):
+    with open(file_path, 'r') as file:
+        return file.read().strip()
+
+
+def get_commit_message(file_path):
+    commit_msg = read_file(file_path)
+    if not validate_commit_message(commit_msg):
+        raise ValueError(
+            "GITGUARD: Commit message does not follow conventions. Fix it and try again.")
+    return commit_msg
+
+
+if __name__ == "__main__":
+    try:
+        print("GITGUARD: Verifying commit message...")
+        commit_msg = get_commit_message(sys.argv[1])
+        print(f"GITGUARD: Commit message verified: {commit_msg}")
+    except ValueError as e:
+        print(e)
+        sys.exit(1)

--- a/.gitguard/gitguard.py
+++ b/.gitguard/gitguard.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import subprocess
+import shutil
+import os
+
+
+def install_commit_hook():
+    print("Starting the script...")
+
+    # Get the git repository path
+    try:
+        print("Fetching the git directory...")
+        git_repo_path = subprocess.check_output(
+            ["git", "rev-parse", "--git-dir"], text=True).strip()
+        print(f"Git directory found: {git_repo_path}")
+    except subprocess.CalledProcessError:
+        print("Failed to find git directory. Are you in a git repo?")
+        return
+
+    commit_msg_file = 'commit-msg'
+    git_hooks_dir = os.path.join(git_repo_path, 'hooks')
+
+    print(f"Checking if commit-msg file exists at {commit_msg_file}...")
+    if not os.path.exists(commit_msg_file):
+        print("Commit-msg file not found. Did you forget to create it?")
+        return
+
+    print(f"Copying commit-msg to {git_hooks_dir}...")
+    try:
+        shutil.copy(commit_msg_file, git_hooks_dir)
+        print("Commit-msg hook installed successfully.")
+    except Exception as e:
+        print(f"Failed to install commit-msg hook: {e}")
+
+
+if __name__ == "__main__":
+    install_commit_hook()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,13 @@ $ python -m starcli --help
 If the above command displayed the help and usage, you are good to go 👍 you can
 also test all the other features like list and table output, debug, etc.
 
+**Setup gitguard**
+```
+$ ./.gitguard/gitguard.py
+```
+
+GitGuard can assist you by ensuring your commits adhere to conventional commit standards. If your commit message doesn't follow these conventions, GitGuard will alert you by throwing an error. This feature helps you maintain a consistent and readable commit history by guiding you in formatting your commit messages correctly.
+
 **Running tests**
 ```bash
 python -m pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ also test all the other features like list and table output, debug, etc.
 
 **Setup gitguard**
 ```
-$ ./.gitguard/gitguard.py
+$ cd .gitguard; ./gitguard.py
 ```
 
 GitGuard can assist you by ensuring your commits adhere to conventional commit standards. If your commit message doesn't follow these conventions, GitGuard will alert you by throwing an error. This feature helps you maintain a consistent and readable commit history by guiding you in formatting your commit messages correctly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,5 +96,5 @@ pylint *.py
 
 **Formatting & code spell**
 ```bash
-black . && codespell --skip=".git,*.json,demo-pics/,venv/"
+black . && codespell --skip=".git,.gitguard/,*.json,demo-pics/,venv/"
 ```


### PR DESCRIPTION
<!--If it's just a typo fix or a very small change, you can put your description
here and ignore everything below-->

**Checklist**

- [x] My code is properly formatted using the latest [black](https://github.com/psf/black) <!--Don't worry if you don't know what this is, the formatting checks will still pass-->
- [x] I have added/updated [tests](https://github.com/hedythedev/starcli/tree/main/tests) if needed <!--pytest-->
- [x] I have tried running my code manually <!-- run using `python3 -m starcli` -->
- [x] I have checked for spelling errors <!--The code will be run through codespell-->
<!--
  Please mark this PR as draft if it is still work in progress
  and feel free to add to this checklist if you like
-->


**Description**

I have successfully integrated GitGuard into our repository to enhance our commit practices. GitGuard enforces conventional commit standards, ensuring all commit messages are consistent and meaningful. This integration will help maintain a clean commit history, making it easier to track changes and understand the context of each update. I'm submitting this pull request to merge the GitGuard integration into the main branch, and I look forward to your feedback and approval.

More Info about [gitguard](https://gitguard.segin.in), also check [blog](https://sebzz.hashnode.dev/gitguard).

